### PR TITLE
gist-5 invalid module name rename module as github.com/mike-neck/gist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gist
+module github.com/mike-neck/gist
 
 go 1.13
 


### PR DESCRIPTION
Fix #5 